### PR TITLE
chore(dependabot): add 7-day cooldown to all update blocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Zurich"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":seedling:"
     labels:
@@ -25,6 +27,8 @@ updates:
       day: "wednesday"
       time: "06:00"
       timezone: "Europe/Zurich"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":robot:"
     labels:
@@ -43,6 +47,8 @@ updates:
       day: "wednesday"
       time: "06:00"
       timezone: "Europe/Zurich"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ":robot:"
     labels:


### PR DESCRIPTION
## What

Adds a 7-day cooldown (`cooldown: { default-days: 7 }`) to every `updates` block in `dependabot.yml`.

## Why

Most malicious package releases (typosquats, hijacked maintainers, malicious post-install) are detected and pulled within 24-72h. A 7-day cooldown keeps us out of that danger window for routine version bumps. **Security updates are exempt from cooldown**, so CVE fixes still land immediately.

7 days is the cross-tool consensus value (Dependabot / Renovate `minimumReleaseAge` / npm `min-release-age`). Part of an org-wide rollout across all repos using Dependabot.

> Note: for `gomod` / `github-actions` / `docker`, Dependabot keys cooldown off the git tag commit date rather than release date, so treat it as defense-in-depth rather than airtight. See dependabot/dependabot-core#13078.